### PR TITLE
Support breakpoints in cppia scripts

### DIFF
--- a/hxcpp-debug-server/hxcpp/debug/jsonrpc/Server.hx
+++ b/hxcpp-debug-server/hxcpp/debug/jsonrpc/Server.hx
@@ -237,6 +237,7 @@ class Server {
 	private function generateFilePathMaps() {
 		#if scriptable
 		var isUpdate = path2file.keys().hasNext();
+		var relativeSourceWarningShown = false;
 		#end
 		var fullPathes = Debugger.getFilesFullPath();
 		var files = Debugger.getFiles();
@@ -245,8 +246,10 @@ class Server {
 			var path = fullPathes[i];
 
 			#if scriptable
-			if (isUpdate && !path2file.exists(path2Key(path)) && !haxe.io.Path.isAbsolute(path)) {
-				log("Warning: cppia script was loaded containing relative source file paths. Make sure the script is compiled with -D cppia.absolute-source-paths");
+			if (isUpdate && !path2file.exists(path2Key(path)) && !haxe.io.Path.isAbsolute(path) && !relativeSourceWarningShown) {
+				log("Warning: cppia script was loaded containing relative source file paths."
+					+ " Make sure the script is compiled with -D cppia.absolute-source-paths");
+				relativeSourceWarningShown = true;
 			}
 			#end
 

--- a/hxcpp-debug-server/hxcpp/debug/jsonrpc/Server.hx
+++ b/hxcpp-debug-server/hxcpp/debug/jsonrpc/Server.hx
@@ -235,11 +235,21 @@ class Server {
 	}
 
 	private function generateFilePathMaps() {
+		#if scriptable
+		var isUpdate = path2file.keys().hasNext();
+		#end
 		var fullPathes = Debugger.getFilesFullPath();
 		var files = Debugger.getFiles();
 		for (i in 0...files.length) {
 			var file = files[i];
 			var path = fullPathes[i];
+
+			#if scriptable
+			if (isUpdate && !path2file.exists(path2Key(path)) && !haxe.io.Path.isAbsolute(path)) {
+				log("Warning: cppia script was loaded containing relative source file paths. Make sure the script is compiled with -D cppia.absolute-source-paths");
+			}
+			#end
+
 			path2file[path2Key(path)] = file;
 			file2path[path2Key(file)] = path;
 		}

--- a/hxcpp-debug-server/hxcpp/debug/jsonrpc/Server.hx
+++ b/hxcpp-debug-server/hxcpp/debug/jsonrpc/Server.hx
@@ -235,24 +235,11 @@ class Server {
 	}
 
 	private function generateFilePathMaps() {
-		#if scriptable
-		var isUpdate = path2file.keys().hasNext();
-		var relativeSourceWarningShown = false;
-		#end
 		var fullPathes = Debugger.getFilesFullPath();
 		var files = Debugger.getFiles();
 		for (i in 0...files.length) {
 			var file = files[i];
 			var path = fullPathes[i];
-
-			#if scriptable
-			if (isUpdate && !path2file.exists(path2Key(path)) && !haxe.io.Path.isAbsolute(path) && !relativeSourceWarningShown) {
-				log("Warning: cppia script was loaded containing relative source file paths."
-					+ " Make sure the script is compiled with -D cppia.absolute-source-paths");
-				relativeSourceWarningShown = true;
-			}
-			#end
-
 			path2file[path2Key(path)] = file;
 			file2path[path2Key(file)] = path;
 		}


### PR DESCRIPTION
In cppia, script source files are not known initially so breakpoints will fail to be set properly.

With this patch, the debug server now assigns its own breakpoint id for failed breakpoints and attempts to readd them whenever a new cppia script is loaded.

This depends on the following patches to haxe and hxcpp:
- https://github.com/HaxeFoundation/haxe/pull/12053
- https://github.com/HaxeFoundation/haxe/pull/12051
- https://github.com/HaxeFoundation/hxcpp/pull/1203